### PR TITLE
Attempting to fix build numbers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,10 @@ source:
 # TODO: run_exports & split outputs once this is a library
 
 build:
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER') }}
-  string: master
+  # conda-smithy assumes that the build number is >= 1000 when building with the new anaconda compilers,
+  # this probably is not important but make_build_number otherwise complains during the build
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER')|int + 1000 }}
+  string: master_{{ environ.get('GIT_DESCRIBE_NUMBER')|int + 1000 }}
   skip: true        # [win]
 
 requirements:


### PR DESCRIPTION
somehow packages are always built as 0.0.0_master but don't include the
build number. Proably because of smithy's special treatment of numbers
<1000.